### PR TITLE
Import opentender data that has defense CPVs

### DIFF
--- a/api/controllers/cpvs.js
+++ b/api/controllers/cpvs.js
@@ -33,12 +33,13 @@ function getTenderCpvs(req, res) {
   if (actorQueries.length) {
     queryCriteria.push(`(${_.join(actorQueries, ' OR ')})`);
   }
-  const cpvsQuery = `SELECT code, xNumberDigits, xName,
+  const cpvsQuery = `SELECT code, xNumberDigits, xName, military,
     bidIDs.size() as xNumberBids
     FROM (
       SELECT cpv.code as code,
       cpv.xNumberDigits as xNumberDigits,
       cpv.xName as xName,
+      cpv.military as military,
       set(bidID) as bidIDs
       FROM (
         SELECT id as bidID, out('BidHasCPV') as cpv

--- a/api/serializers/cpv.js
+++ b/api/serializers/cpv.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 
 function formatCpv(cpvNode) {
-  return _.pick(cpvNode, ['code', 'xName', 'xNumberDigits', 'xNumberBids']);
+  return _.pick(cpvNode, ['code', 'xName', 'xNumberDigits', 'xNumberBids', 'military']);
 }
 
 module.exports = {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1543,7 +1543,7 @@ definitions:
                                   nodeID:
                                     type: string
                                     description: ID of the node corresponding to this actor in the Network
-                                    format: uuid                
+                                    format: uuid
   Bid:
     type: object
     description: The bid applied to win a certain lot
@@ -1655,6 +1655,7 @@ definitions:
       - code
       - xName
       - xNumberDigits
+      - military
     properties:
       code:
         type: string
@@ -1668,6 +1669,9 @@ definitions:
       xNumberBids:
         type: integer
         description: Number of bids with this CPV
+      military:
+        type: boolean
+        description: Is the CPV related to military activities or not
   CountryIndexResponse:
     type: object
     properties:

--- a/extractors/cpv.js
+++ b/extractors/cpv.js
@@ -7,6 +7,7 @@ function extractCpv(cpvAttrs) {
     xName: cpvAttrs.name,
     code: extractCpvCode(cpvAttrs.code),
     xNumberDigits: cpvAttrs.xNumberDigits,
+    military: cpvAttrs.military,
   };
 }
 

--- a/migrations/m20190320_125108_add_military_to_cpv.js
+++ b/migrations/m20190320_125108_add_military_to_cpv.js
@@ -1,0 +1,26 @@
+'use strict';
+
+exports.name = 'add military to cpv';
+
+exports.up = (db) => (
+  db.class.get('CPV')
+    .then((CPV) =>
+      CPV.property.create([
+        {
+          name: 'military',
+          type: 'Boolean',
+        },
+      ]))
+    .then(() =>
+      db.index.create({
+        name: 'CPV.military',
+        type: 'NOTUNIQUE_HASH_INDEX',
+      }))
+);
+
+exports.down = (db) => (
+  db.index.drop('CPV.military')
+    .then(() => db.class.get('CPV'))
+    .then((CPV) => CPV.property.drop('military'))
+);
+

--- a/scripts/import_cpvs.js
+++ b/scripts/import_cpvs.js
@@ -10,35 +10,46 @@ const config = require('../config/default');
 const helpers = require('./helpers');
 
 const cpvsURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/cpv_codes.json');
+const militaryCpvsURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/military_cpv_codes.json');
 
-function importCPVs() {
-  helpers.fetchRemoteFile(cpvsURL)
-    .then((cpvList) => {
-      console.log('Upserting CPVs...');
-      return Promise.map(cpvList, (rawCpv) => {
-        const cpv = {
-          code: rawCpv.code,
-          xName: rawCpv.text,
-          xNumberDigits: rawCpv.number_digits,
-        };
-        return config.db.select().from('CPV')
-          .where({ code: cpv.code })
-          .one()
-          .then((existingCpv) => {
-            if (_.isUndefined(existingCpv)) {
-              return config.db.create('vertex', 'CPV')
-                .set(cpv)
-                .commit()
-                .one();
-            }
-            return config.db.update('CPV')
-              .set(cpv)
-              .where({ '@rid': existingCpv['@rid'] })
-              .return('AFTER')
-              .commit()
-              .one();
+function upsertCpv(cpvRecord) {
+  return config.db.select().from('CPV')
+    .where({ code: cpvRecord.code })
+    .one()
+    .then((existingCpv) => {
+      if (_.isUndefined(existingCpv)) {
+        return config.db.create('vertex', 'CPV')
+          .set(cpvRecord)
+          .commit()
+          .one();
+      }
+      return config.db.update('CPV')
+        .set(cpvRecord)
+        .where({ '@rid': existingCpv['@rid'] })
+        .return('AFTER')
+        .commit()
+        .one();
+    });
+}
+
+function importMilitaryCpvs() {
+  console.log('Retrieving military CPVs...');
+  return helpers.fetchRemoteFile(militaryCpvsURL)
+    .then((militaryCpvList) => {
+      console.log('Retrieving all CPVs...');
+      return helpers.fetchRemoteFile(cpvsURL)
+        .then((cpvList) => {
+          console.log('Upserting CPVs...');
+          return Promise.map(cpvList, (rawCpv) => {
+            const cpv = {
+              code: rawCpv.code,
+              xName: rawCpv.text,
+              xNumberDigits: rawCpv.number_digits,
+              military: !_.isUndefined(_.find(militaryCpvList, { code: rawCpv.code })),
+            };
+            return upsertCpv(cpv);
           });
-      });
+        });
     })
     .then((writtenCPVs) => {
       console.log(`Upserted ${writtenCPVs.length} CPVs`);
@@ -50,4 +61,4 @@ function importCPVs() {
     });
 }
 
-importCPVs();
+importMilitaryCpvs();

--- a/test/api/controllers/cpvs.js
+++ b/test/api/controllers/cpvs.js
@@ -23,6 +23,7 @@ function expectedResponse(matchTenderID) {
     .then((writtenCpvs) => ({
       cpvs: _.map(_.sortBy(writtenCpvs, 'code'), (cpv) => {
         cpv.xNumberBids = 1;
+        cpv.military = true;
         return cpvSerializer.formatCpv(cpv);
       }),
     }));

--- a/test/api/writers/tender.js
+++ b/test/api/writers/tender.js
@@ -477,3 +477,32 @@ test.serial('upsertCpv allows cpv to have edges to more than one tender', async 
     _.sortBy(_.map(writtenEdges, (edge) => edge.out.toString())),
   );
 });
+
+test.serial('hasMilitaryCPV returns false if none of the CPVs is military', async (t) => {
+  t.plan(1);
+  const militaryCpv = await fixtures.build('rawCpv', {
+    code: '35613000',
+    military: true,
+  });
+  await config.db.create('vertex', 'CPV')
+    .set(militaryCpv)
+    .commit()
+    .one();
+  const nonMilitaryCpv = await fixtures.build('rawCpv', { code: '03222111' });
+  const nonMilitaryCpv2 = await fixtures.build('rawCpv', { code: '03222112' });
+  t.is(await writers.hasMilitaryCpv([nonMilitaryCpv, nonMilitaryCpv2]), false);
+});
+
+test.serial('hasMilitaryCPV returns true if at least one of the CPVs is military', async (t) => {
+  t.plan(1);
+  const militaryCpv = await fixtures.build('rawCpv', {
+    code: '35613000',
+    military: true,
+  });
+  await config.db.create('vertex', 'CPV')
+    .set(militaryCpv)
+    .commit()
+    .one();
+  const nonMilitaryCpv = await fixtures.build('rawCpv', { code: '03222111' });
+  t.is(await writers.hasMilitaryCpv([nonMilitaryCpv, militaryCpv]), true);
+});

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -31,6 +31,7 @@ const cpvAttrs = {
   code: factory.sequence((n) => `12021220${n}`),
   name: 'Talkative ghosts',
   xNumberDigits: 3,
+  military: true,
 };
 factory.define('rawCpv', Object, cpvAttrs);
 factory.define('extractedCpv', Object, cpvAttrs, {


### PR DESCRIPTION
This PR adds a `military` attribute to CPVs. This is needed because we only include tenders from [opentender.eu](opentender.eu) that have at least one military CPV.
