### PR TITLE
Add sources to Tender and Bid.

### DIFF
--- a/extractors/bid.js
+++ b/extractors/bid.js
@@ -25,6 +25,7 @@ function extractBid(bidAttrs, tenderAttrs, lotAttrs) {
       .head()
       .get('sourceId')
       .value(),
+    sources: extractSources(tenderAttrs.publications),
   };
 }
 
@@ -34,6 +35,12 @@ function extractYear(awardDecisionDate) {
     year = moment(awardDecisionDate).year();
   }
   return year;
+}
+
+function extractSources(publications) {
+  const awardNotices = _.filter(publications, { formType: 'CONTRACT_AWARD' });
+  const sourceURLs = _.map(awardNotices, 'humanReadableUrl');
+  return sourceURLs;
 }
 
 module.exports = {

--- a/extractors/tender.js
+++ b/extractors/tender.js
@@ -28,6 +28,7 @@ function extractTender(tenderAttrs, indicators = [], publications = []) {
       'sourceId',
     ),
     year: extractYear(publications),
+    sources: extractSources(publications),
   };
 }
 
@@ -59,6 +60,13 @@ function extractYear(publications) {
   }
   return year;
 }
+
+function extractSources(publications) {
+  const contractNotices = _.filter(publications, { formType: 'CONTRACT_NOTICE' });
+  const sourceURLs = _.map(contractNotices, 'humanReadableUrl');
+  return sourceURLs;
+}
+
 module.exports = {
   extractTender,
 };

--- a/migrations/m20190326_153149_add_sources_to_tender.js
+++ b/migrations/m20190326_153149_add_sources_to_tender.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.name = 'add sources to tender';
+
+exports.up = (db) => (
+  db.class.get('Tender')
+    .then((Tender) =>
+      Tender.property.create([
+        {
+          name: 'sources',
+          type: 'EmbeddedSet',
+        },
+      ]))
+);
+
+exports.down = (db) => (
+  db.class.get('Tender')
+    .then((Tender) => Tender.property.drop('sources'))
+);
+

--- a/migrations/m20190326_153615_add_sources_to_bid.js
+++ b/migrations/m20190326_153615_add_sources_to_bid.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.name = 'add sources to bid';
+
+exports.up = (db) => (
+  db.class.get('Bid')
+    .then((Bid) =>
+      Bid.property.create([
+        {
+          name: 'sources',
+          type: 'EmbeddedSet',
+        },
+      ]))
+);
+
+exports.down = (db) => (
+  db.class.get('Bid')
+    .then((Bid) => Bid.property.drop('sources'))
+);
+

--- a/test/extractors/bid.js
+++ b/test/extractors/bid.js
@@ -39,3 +39,26 @@ test('extractBid extracts year from lots award decision date', async (t) => {
     year,
   );
 });
+
+test('extractBid extracts sources from award notice publications', async (t) => {
+  const publication = await fixtures.build('rawContractAwardNotice');
+  const rawBid = await fixtures.build('rawBid');
+  const rawTender = await fixtures.build('rawTender', {
+    publications: [publication],
+  });
+  t.deepEqual(
+    bidExtractor.extractBid(rawBid, rawTender, {}).sources,
+    [publication.humanReadableUrl],
+  );
+});
+
+test('extractBid returns expty set of sources if there is no publication', async (t) => {
+  const rawBid = await fixtures.build('rawBid');
+  const rawTender = await fixtures.build('rawTender', {
+    publications: [],
+  });
+  t.deepEqual(
+    bidExtractor.extractBid(rawBid, rawTender, {}).sources,
+    [],
+  );
+});

--- a/test/extractors/tender.js
+++ b/test/extractors/tender.js
@@ -23,6 +23,23 @@ test('extractTender returns null if there is no publication', async (t) => {
   );
 });
 
+test('extractTender extracts sources from contract notice publications', async (t) => {
+  const publication = await fixtures.build('rawContractNotice');
+  const rawTender = await fixtures.build('rawTender');
+  t.deepEqual(
+    tenderExtractor.extractTender(rawTender, [], [publication]).sources,
+    [publication.humanReadableUrl],
+  );
+});
+
+test('extractTender returns empty set of sources if there is no publication', async (t) => {
+  const rawTender = await fixtures.build('rawTender');
+  t.deepEqual(
+    tenderExtractor.extractTender(rawTender, [], []).sources,
+    [],
+  );
+});
+
 test('extractTender extracts year from contract notice if available', async (t) => {
   const publication = await fixtures.build('rawContractNotice', {
     publicationDate: '2015-11-03',
@@ -45,7 +62,7 @@ test('extractTender extracts year from contract award notice if contract notice 
   );
 });
 
-test('extractTender return undefined if no relevant publication is available', async (t) => {
+test('extractTender returns undefined year if no relevant publication is available', async (t) => {
   const rawTender = await fixtures.build('rawTender');
   t.is(
     tenderExtractor.extractTender(rawTender, [], []).year,

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -132,12 +132,14 @@ factory.define('rawContractNotice', Object, {
   publicationDate: '2017-09-15',
   sourceId: '2015/S 006-hocuspocus',
   formType: 'CONTRACT_NOTICE',
+  humanReadableUrl: 'http://example.com',
 });
 
 factory.define('rawContractAwardNotice', Object, {
   publicationDate: '2017-09-15',
   sourceId: '2015/S 006-preparatus',
   formType: 'CONTRACT_AWARD',
+  humanReadableUrl: 'http://example.com',
 });
 
 module.exports = factory;


### PR DESCRIPTION
As requested in #5, this PR adds a `sources` attribute to `Tender` and `Bid`. `sources` will be an array of links to the original records (contract notices or contract award notices).