### PR TITLE
Import tenders that fall under Directive 2009/81/EC

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -99,4 +99,11 @@ config.activation = {
   externalUrl: process.env.ACCOUNT_ACTIVATION_URL,
 };
 
+config.staticDataUrls = {
+  cpvs: process.env.CPV_LIST_URL || 'https://raw.githubusercontent.com/tenders-exposed/data_sources/master/cpv_codes.json',
+  militaryCpvs: process.env.MILITARY_CPV_LIST_URL || 'https://raw.githubusercontent.com/tenders-exposed/data_sources/master/military_cpv_codes.json',
+  countries: process.env.COUNTRIES_LIST_URL || 'https://raw.githubusercontent.com/tenders-exposed/data_sources/master/countrynames_iso2_correspondence.json',
+  directiveTenders: process.env.DIRECTIVE_TENDERS_LIST_URL || 'https://raw.githubusercontent.com/tenders-exposed/data_sources/master/tenders_200981EC_directive.csv',
+};
+
 module.exports = config;

--- a/config/default.js
+++ b/config/default.js
@@ -103,7 +103,7 @@ config.staticDataUrls = {
   cpvs: process.env.CPV_LIST_URL || 'https://raw.githubusercontent.com/tenders-exposed/data_sources/master/cpv_codes.json',
   militaryCpvs: process.env.MILITARY_CPV_LIST_URL || 'https://raw.githubusercontent.com/tenders-exposed/data_sources/master/military_cpv_codes.json',
   countries: process.env.COUNTRIES_LIST_URL || 'https://raw.githubusercontent.com/tenders-exposed/data_sources/master/countrynames_iso2_correspondence.json',
-  directiveTenders: process.env.DIRECTIVE_TENDERS_LIST_URL || 'https://raw.githubusercontent.com/tenders-exposed/data_sources/master/tenders_200981EC_directive.csv',
+  directiveTenders: process.env.DIRECTIVE_TENDERS_LIST_URL || 'https://raw.githubusercontent.com/tenders-exposed/data_sources/master/ted_can_200981EC_directive.json',
 };
 
 module.exports = config;

--- a/migrations/m20190330_105121_create_directivecan_class.js
+++ b/migrations/m20190330_105121_create_directivecan_class.js
@@ -1,0 +1,23 @@
+'use strict';
+
+exports.name = 'create directivecan class';
+
+
+exports.up = (db) => (
+  db.class.create('DirectiveCAN')
+    .then((DirectiveCAN) =>
+      DirectiveCAN.property.create([
+        {
+          name: 'sourceUrl',
+          type: 'String',
+          mandatory: true,
+        },
+      ]))
+    .then(() =>
+      db.index.create({
+        name: 'DirectiveCAN.sourceUrl',
+        type: 'UNIQUE_HASH_INDEX',
+      }))
+);
+
+exports.down = (db) => db.class.drop('DirectiveCAN');

--- a/scripts/import_countries.js
+++ b/scripts/import_countries.js
@@ -9,10 +9,8 @@ const Promise = require('bluebird');
 const config = require('../config/default');
 const helpers = require('./helpers');
 
-const countriesURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/countrynames_iso2_correspondence.json');
-
 function importCountries() {
-  helpers.fetchRemoteFile(countriesURL)
+  helpers.fetchRemoteFile(new URL(config.staticDataUrls.countries))
     .then((countriesMapping) => {
       console.log('Upserting countries...');
       return Promise.all(_.values(_.mapValues(countriesMapping, (name, code) =>

--- a/scripts/import_cpvs.js
+++ b/scripts/import_cpvs.js
@@ -9,9 +9,6 @@ const Promise = require('bluebird');
 const config = require('../config/default');
 const helpers = require('./helpers');
 
-const cpvsURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/cpv_codes.json');
-const militaryCpvsURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/military_cpv_codes.json');
-
 function upsertCpv(cpvRecord) {
   return config.db.select().from('CPV')
     .where({ code: cpvRecord.code })
@@ -34,10 +31,10 @@ function upsertCpv(cpvRecord) {
 
 function importMilitaryCpvs() {
   console.log('Retrieving military CPVs...');
-  return helpers.fetchRemoteFile(militaryCpvsURL)
+  return helpers.fetchRemoteFile(new URL(config.staticDataUrls.militaryCpvs))
     .then((militaryCpvList) => {
       console.log('Retrieving all CPVs...');
-      return helpers.fetchRemoteFile(cpvsURL)
+      return helpers.fetchRemoteFile(new URL(config.staticDataUrls.cpvs))
         .then((cpvList) => {
           console.log('Upserting CPVs...');
           return Promise.map(cpvList, (rawCpv) => {

--- a/scripts/import_directive.js
+++ b/scripts/import_directive.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+
+'use strict';
+
+const _ = require('lodash');
+const { URL } = require('url');
+const Promise = require('bluebird');
+
+const config = require('../config/default');
+const helpers = require('./helpers');
+
+function importDirective() {
+  helpers.fetchRemoteFile(new URL(config.staticDataUrls.directiveTenders))
+    .then((directiveTenders) => {
+      console.log('Upserting CAN sources under directive...');
+      return Promise.map(directiveTenders, (sourceUrl) =>
+        config.db.select().from('DirectiveCAN')
+          .where({ sourceUrl })
+          .one()
+          .then((existingCANSource) => {
+            if (_.isUndefined(existingCANSource)) {
+              return config.db.class.get('DirectiveCAN')
+                .then((DirectiveCAN) => DirectiveCAN.create({ sourceUrl }));
+            }
+            return config.db.update(existingCANSource['@rid']).set({ sourceUrl }).one();
+          }));
+    })
+    .then((writtenDirectiveTenders) => {
+      console.log(`Upserted ${writtenDirectiveTenders.length} CAN sources under directive`);
+      process.exit();
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(-1);
+    });
+}
+
+importDirective();


### PR DESCRIPTION
Closes #3.

This PR adds functionality to also import from opentender the tenders that fall under Directive 2009/81/EC.  Unfortunately this information about tenders is only included in the TED export, we don't have it in Opentender. So we made a separate [list of them](https://github.com/tenders-exposed/data_sources/blob/master/ted_can_200981EC_directive.json) which we filter on. 