### PR TITLE
Add isDirective to Tender

### DIFF
--- a/api/serializers/tender.js
+++ b/api/serializers/tender.js
@@ -16,9 +16,10 @@ const actorSerializer = require('./actor');
 
 tenderSerializer.formatTender = function (tender) {
   const formattedTender = _.pick(tender, ['id', 'title', 'titleEnglish', 'description',
-    'isCoveredByGpa', 'isFrameworkAgreement', 'procedureType', 'year', 'country']);
+    'isCoveredByGpa', 'isFrameworkAgreement', 'procedureType', 'year', 'country', 'isDirective']);
   formattedTender.isEUFunded = tender.xIsEuFunded;
   formattedTender.TEDCNID = tender.xTEDCNID;
+  formattedTender.isDirective = tender.xIsDirective;
   formattedTender.finalValue = _.get(tender, 'finalPrice.netAmountEur') || undefined;
   return formattedTender;
 };

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1643,6 +1643,9 @@ definitions:
         type: number
         format: double
         description: Total value of all the winning bids in the tender
+      isDirective:
+        type: boolean
+        description: Is the tender part of Directive 2009/81/EC
   CpvIndexResponse:
     type: object
     properties:

--- a/api/writers/tender.js
+++ b/api/writers/tender.js
@@ -19,7 +19,7 @@ function recordName(id, className) {
 
 // Returns true
 // Raises OrientDBError if the writing failed
-async function writeTender(fullTenderRecord) {
+async function writeTender(fullTenderRecord, skipMilitaryFilters = false) {
   const awardedLots = _.filter(fullTenderRecord.lots, { status: 'AWARDED' });
 
   // If there are no awarded lots don't even process the tender
@@ -36,10 +36,12 @@ async function writeTender(fullTenderRecord) {
 
   // If the tender doesn't have at least one military CPV
   // and it's also not part of Directive 2009/81/EC skip it
-  tender.xIsDirective = await isUnderDirective(fullTenderRecord.publications);
-  const militaryCpv = await hasMilitaryCpv(fullTenderRecord.cpvs);
-  if (militaryCpv === false && tender.xIsDirective === false) {
-    return new Promise((resolve) => resolve(null));
+  if (skipMilitaryFilters === false) {
+    tender.xIsDirective = await isUnderDirective(fullTenderRecord.publications);
+    const militaryCpv = await hasMilitaryCpv(fullTenderRecord.cpvs);
+    if (militaryCpv === false && tender.xIsDirective === false) {
+      return new Promise((resolve) => resolve(null));
+    }
   }
 
   // Otherwise it can be considered a military tender and we should process it

--- a/migrations/m20190408_131324_add_xIsDirective_to_tender.js
+++ b/migrations/m20190408_131324_add_xIsDirective_to_tender.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.name = 'add xIsDirective to tender';
+
+exports.up = (db) => (
+  db.class.get('Tender')
+    .then((Tender) =>
+      Tender.property.create([
+        {
+          name: 'xIsDirective',
+          type: 'Boolean',
+        },
+      ]))
+);
+
+exports.down = (db) => (
+  db.class.get('Tender')
+    .then((Tender) => Tender.property.drop('xIsDirective'))
+);

--- a/test/api/controllers/actors.js
+++ b/test/api/controllers/actors.js
@@ -39,7 +39,7 @@ test.serial('getTenderActors returns all actors by default', async (t) => {
       buyers: [buyer],
       lots: [lot],
     }))
-    .then((rawTender) => writers.writeTender(rawTender));
+    .then((rawTender) => writers.writeTender(rawTender, true));
   const res = await request(app)
     .get('/tenders/actors');
 
@@ -54,7 +54,7 @@ test.serial('getTenderActors limits actors to limit', async (t) => {
   await fixtures.build('rawFullTender', {
     buyers: [buyer, secondBuyer],
   })
-    .then((rawTender) => writers.writeTender(rawTender));
+    .then((rawTender) => writers.writeTender(rawTender, true));
   const res = await request(app)
     .get('/tenders/actors?limit=1');
 
@@ -74,11 +74,11 @@ test.serial('getTenderActors filters actors by cpvs', async (t) => {
       lots: [lot],
       cpvs: [cpv],
     }))
-    .then((rawTender) => writers.writeTender(rawTender));
+    .then((rawTender) => writers.writeTender(rawTender, true));
   await fixtures.build('rawFullTender', {
     cpvs: fixtures.buildMany('rawCpv', 1),
     buyers: fixtures.buildMany('rawBuyer', 1, { '@class': 'Buyer' }),
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/actors?cpvs=${cpv.code}`);
 
@@ -101,7 +101,7 @@ test.serial('getTenderActors filters actors by year', async (t) => {
       buyers: [expectedBuyer],
       lots: [lot],
     }))
-    .then((rawTender) => writers.writeTender(rawTender));
+    .then((rawTender) => writers.writeTender(rawTender, true));
   await fixtures.build('rawLot', {
     awardDecisionDate: `${alternativeYear}-01-10`,
   })
@@ -109,7 +109,7 @@ test.serial('getTenderActors filters actors by year', async (t) => {
       lots: [lot],
       buyers: fixtures.buildMany('rawBuyer', 1, { '@class': 'Buyer' }),
     }))
-    .then((ten) => writers.writeTender(ten));
+    .then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/actors?years=${expectedYear},2017`);
 
@@ -130,11 +130,11 @@ test.serial('getTenderActors filters actors by countries', async (t) => {
       lots: [lot],
       country: expectedCountry,
     }))
-    .then((rawTender) => writers.writeTender(rawTender));
+    .then((rawTender) => writers.writeTender(rawTender, true));
   await fixtures.build('rawFullTender', {
     country: alternativeContry,
     buyers: fixtures.buildMany('rawBuyer', 1, { '@class': 'Buyer' }),
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/actors?countries[]=${expectedCountry}`);
 
@@ -154,7 +154,7 @@ test.serial('getTenderActors provides sugestions based on name', async (t) => {
   });
   await fixtures.build('rawFullTender', {
     buyers: [expectedBuyer, alternativeBuyer],
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get('/tenders/actors?name=minis');
 
@@ -174,7 +174,7 @@ test.serial('getTenderActors allows lucene queries', async (t) => {
   });
   await fixtures.build('rawFullTender', {
     buyers: [expectedBuyer, alternativeBuyer],
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
 
   const res = await request(app)
     .get('/tenders/actors?name=ministry AND magic');
@@ -195,7 +195,7 @@ test.serial('getTenderActors ackowledges whitespace in query string', async (t) 
   });
   await fixtures.build('rawFullTender', {
     buyers: [expectedBuyer, alternativeBuyer],
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
 
   const res = await request(app)
     .get('/tenders/actors?name=expelli%20%20');
@@ -221,7 +221,7 @@ test.serial('getTenderActors ackowledges whitespace in query string', async (t) 
 //       buyers: [expectedBuyer],
 //       lots: [lot],
 //     }))
-//     .then((rawTender) => writers.writeTender(rawTender));
+//     .then((rawTender) => writers.writeTender(rawTender, true));
 //   const res = await request(app)
 //     .get('/tenders/actors?name=azkaban~');
 

--- a/test/api/controllers/countries.js
+++ b/test/api/controllers/countries.js
@@ -36,7 +36,7 @@ test.serial('getTenderCountries returns all cpvs by default', async (t) => {
   t.plan(2);
   const expectedCountry = 'CZ';
   await fixtures.build('rawFullTender', { country: expectedCountry })
-    .then((rawTender) => writers.writeTender(rawTender));
+    .then((rawTender) => writers.writeTender(rawTender, true));
   const res = await request(app)
     .get('/tenders/countries');
 
@@ -52,11 +52,11 @@ test.serial('getTenderCountries filters countries by cpvs', async (t) => {
   await fixtures.build('rawFullTender', {
     cpvs: [cpv],
     country: expectedCountry,
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawFullTender', {
     cpvs: fixtures.assocAttrsMany('rawCpv', 2),
     country: alternativeCountry,
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/countries?cpvs=${cpv.code}`);
 
@@ -72,10 +72,10 @@ test.serial('getTenderCountries filters countries by buyer', async (t) => {
   await fixtures.build('rawFullTender', {
     buyers: [buyer],
     country: expectedCountry,
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawFullTender', {
     country: alternativeCountry,
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/countries?buyers[]=${buyer.id}`);
 
@@ -94,10 +94,10 @@ test.serial('getTenderCountries filters countries by bidder', async (t) => {
       lots: [lot],
       country: expectedCountry,
     }))
-    .then((ten) => writers.writeTender(ten));
+    .then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawFullTender', {
     country: alternativeCountry,
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/countries?bidders[]=${bidder.id}`);
 
@@ -116,7 +116,7 @@ test.serial('getTenderCountries filters countries by year', async (t) => {
       lots: [lot],
       country: expectedCountry,
     }))
-    .then((ten) => writers.writeTender(ten));
+    .then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawLot', {
     awardDecisionDate: '2017-01-10',
   })
@@ -124,7 +124,7 @@ test.serial('getTenderCountries filters countries by year', async (t) => {
       lots: [lot],
       country: alternativeCountry,
     }))
-    .then((ten) => writers.writeTender(ten));
+    .then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get('/tenders/countries?years=2016,2017');
 

--- a/test/api/controllers/cpvs.js
+++ b/test/api/controllers/cpvs.js
@@ -41,7 +41,7 @@ test.serial('getTenderCpvs returns all cpvs by default', async (t) => {
   t.plan(2);
   const cpvs = fixtures.assocAttrsMany('rawCpv', 2);
   const tender = await fixtures.build('rawFullTender', { cpvs })
-    .then((rawTender) => writers.writeTender(rawTender));
+    .then((rawTender) => writers.writeTender(rawTender, true));
   const res = await request(app)
     .get('/tenders/cpvs');
 
@@ -54,11 +54,11 @@ test.serial('getTenderCpvs filters cpvs by country', async (t) => {
   const rawMatchTender = await fixtures.build('rawFullTender', {
     cpvs: fixtures.assocAttrsMany('rawCpv', 2),
     country: 'RO',
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawFullTender', {
     cpvs: fixtures.assocAttrsMany('rawCpv', 2),
     country: 'NL',
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get('/tenders/cpvs?countries[]=RO');
 
@@ -72,10 +72,10 @@ test.serial('getTenderCpvs filters cpvs by buyer', async (t) => {
   const rawMatchTender = await fixtures.build('rawFullTender', {
     cpvs: fixtures.assocAttrsMany('rawCpv', 2),
     buyers: [buyer],
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawFullTender', {
     cpvs: fixtures.assocAttrsMany('rawCpv', 2),
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/cpvs?buyers[]=${buyer.id}`);
 
@@ -92,10 +92,10 @@ test.serial('getTenderCpvs filters cpvs by bidder', async (t) => {
       cpvs: fixtures.assocAttrsMany('rawCpv', 2),
       lots: [lot],
     }))
-    .then((ten) => writers.writeTender(ten));
+    .then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawFullTender', {
     cpvs: fixtures.assocAttrsMany('rawCpv', 2),
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/cpvs?bidders[]=${bidder.id}`);
 
@@ -115,11 +115,11 @@ test.serial('getTenderCpvs filters cpvs by bidder or buyer', async (t) => {
       cpvs: [bidderCpv],
       lots: [lot],
     }))
-    .then((ten) => writers.writeTender(ten));
+    .then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawFullTender', {
     cpvs: [buyerCpv],
     buyers: [buyer],
-  }).then((ten) => writers.writeTender(ten));
+  }).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/cpvs?bidders[]=${bidder.id}&buyers[]=${buyer.id}`);
   t.is(res.status, codes.SUCCESS);
@@ -149,7 +149,7 @@ test.serial('getTenderCpvs filters cpvs by year', async (t) => {
       cpvs: fixtures.assocAttrsMany('rawCpv', 2),
       lots: [lot],
     }))
-    .then((ten) => writers.writeTender(ten));
+    .then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawLot', {
     awardDecisionDate: '2017-01-10',
   })
@@ -157,7 +157,7 @@ test.serial('getTenderCpvs filters cpvs by year', async (t) => {
       cpvs: fixtures.assocAttrsMany('rawCpv', 2),
       lots: [lot],
     }))
-    .then((ten) => writers.writeTender(ten));
+    .then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get('/tenders/cpvs?years=2016,2017');
 

--- a/test/api/controllers/networks.js
+++ b/test/api/controllers/networks.js
@@ -60,7 +60,7 @@ test.serial('createNetwork returns network with nodes and edges', async (t) => {
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   const networkParams = {
     network: {
       query: {

--- a/test/api/controllers/years.js
+++ b/test/api/controllers/years.js
@@ -27,7 +27,7 @@ test.serial('getTenderYears returns all years by default', async (t) => {
     awardDecisionDate: `${expectedYear}-01-17`,
   });
   await fixtures.build('rawFullTender', { lots: [lot] })
-    .then((rawTender) => writers.writeTender(rawTender));
+    .then((rawTender) => writers.writeTender(rawTender, true));
   const res = await request(app)
     .get('/tenders/years');
 
@@ -45,13 +45,13 @@ test.serial('getTenderYears filters years by cpvs', async (t) => {
   }).then((lot) => fixtures.build('rawFullTender', {
     cpvs: [cpv],
     lots: [lot],
-  })).then((ten) => writers.writeTender(ten));
+  })).then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawLotWithBid', {
     awardDecisionDate: `${alternativeYear}-01-17`,
   }).then((lot) => fixtures.build('rawFullTender', {
     cpvs: fixtures.assocAttrsMany('rawCpv', 2),
     lots: [lot],
-  })).then((ten) => writers.writeTender(ten));
+  })).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/years?cpvs=${cpv.code}`);
 
@@ -69,12 +69,12 @@ test.serial('getTenderYears filters years by buyer', async (t) => {
   }).then((lot) => fixtures.build('rawFullTender', {
     buyers: [buyer],
     lots: [lot],
-  })).then((ten) => writers.writeTender(ten));
+  })).then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawLotWithBid', {
     awardDecisionDate: `${alternativeYear}-01-17`,
   }).then((lot) => fixtures.build('rawFullTender', {
     lots: [lot],
-  })).then((ten) => writers.writeTender(ten));
+  })).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/years?buyers[]=${buyer.id}`);
 
@@ -95,12 +95,12 @@ test.serial('getTenderYears filters years by bidder', async (t) => {
     .then((lot) => fixtures.build('rawFullTender', {
       lots: [lot],
     }))
-    .then((ten) => writers.writeTender(ten));
+    .then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawLotWithBid', {
     awardDecisionDate: `${alternativeYear}-01-17`,
   }).then((lot) => fixtures.build('rawFullTender', {
     lots: [lot],
-  })).then((ten) => writers.writeTender(ten));
+  })).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/years?bidders[]=${bidder.id}`);
 
@@ -119,13 +119,13 @@ test.serial('getTenderYears filters years by countries', async (t) => {
   }).then((lot) => fixtures.build('rawFullTender', {
     lots: [lot],
     country: expectedCountry,
-  })).then((ten) => writers.writeTender(ten));
+  })).then((ten) => writers.writeTender(ten, true));
   await fixtures.build('rawLotWithBid', {
     awardDecisionDate: `${alternativeYear}-01-17`,
   }).then((lot) => fixtures.build('rawFullTender', {
     lots: [lot],
     country: alternativeCountry,
-  })).then((ten) => writers.writeTender(ten));
+  })).then((ten) => writers.writeTender(ten, true));
   const res = await request(app)
     .get(`/tenders/years?countries=${expectedCountry},PL`);
 

--- a/test/api/writers/actor_cluster.js
+++ b/test/api/writers/actor_cluster.js
@@ -27,12 +27,12 @@ async function createNetwork() {
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   await fixtures.build('rawFullTender', {
     buyers: _.takeRight(buyers, 2),
     country: 'CZ',
   })
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   const networkParams = {
     query: {
       countries: ['CZ'],

--- a/test/api/writers/network.js
+++ b/test/api/writers/network.js
@@ -71,7 +71,7 @@ test.serial('createNetwork filters bids by query', async (t) => {
       cpvs: [queryCpv],
       country: queryCountry,
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   await fixtures.build('rawBidWithBidder', { bidders: [queryBidder] })
     .then((bid) => fixtures.build('rawLot', {
       bids: [bid],
@@ -83,11 +83,11 @@ test.serial('createNetwork filters bids by query', async (t) => {
       cpvs: [queryCpv],
       country: queryCountry,
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   await fixtures.build('rawFullTender', {
     country: 'NL',
   })
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   const networkParams = {
     query: {
       countries: [queryCountry],
@@ -158,7 +158,7 @@ test.serial('createNetwork creates network actors ', async (t) => {
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   const networkParams = {
     query: {
       countries: ['CZ'],
@@ -181,7 +181,7 @@ test.serial('createNetwork creates actor even if the counterpart misses', async 
   await fixtures.build('rawFullTender', {
     buyers: [buyer],
     country: 'CZ',
-  }).then((rawTender) => tenderWriters.writeTender(rawTender));
+  }).then((rawTender) => tenderWriters.writeTender(rawTender, true));
   const networkParams = {
     query: {
       countries: ['CZ'],
@@ -207,7 +207,7 @@ test.serial('createNetwork creates network edges ', async (t) => {
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   const networkParams = {
     query: {
       countries: ['CZ'],
@@ -237,7 +237,7 @@ test.serial('createNetwork uses number of winning bids for node size', async (t)
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   const networkParams = {
     query: {
       countries: ['CZ'],
@@ -272,7 +272,7 @@ test.serial('createNetwork uses amount of money exchanged for node size', async 
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   const networkParams = {
     query: {
       countries: ['CZ'],
@@ -301,7 +301,7 @@ test.serial('createNetwork uses number of winning bids for contracts edge size '
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender)));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true)));
   const networkParams = {
     query: {
       countries: ['CZ'],
@@ -333,7 +333,7 @@ test.serial('createNetwork uses amount of money exchanged bids for contracts edg
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender)));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true)));
   const networkParams = {
     query: {
       countries: ['CZ'],
@@ -360,7 +360,7 @@ test.serial('createNetwork uses number of shared bids for partners edge size ', 
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender)));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true)));
   const networkParams = {
     query: {
       countries: ['CZ'],
@@ -389,12 +389,12 @@ test.serial('createNetwork calculates medianCompetition for nodes', async (t) =>
       lots: [rawLot],
       country: 'CZ',
     }))
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   await fixtures.build('rawFullTender', {
     buyers: _.takeRight(buyers, 2),
     country: 'CZ',
   })
-    .then((rawTender) => tenderWriters.writeTender(rawTender));
+    .then((rawTender) => tenderWriters.writeTender(rawTender, true));
   const networkParams = {
     query: {
       countries: ['CZ'],

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -39,6 +39,7 @@ async function truncateDB() {
     'Price',
     'Address',
     'User',
+    'DirectiveCAN',
   ];
 
   await Promise.map(dbClasses, (className) =>


### PR DESCRIPTION
It's important to know which tenders got into our database because they fall under Directive 2009/81/EC.

This PR adds that functionality.
There are now also tests to make sure we only write tenders that fulfill at least one of the criteria for being military, namely:
- they are under directive
- they have a military cpv
In order to add these tests without breaking all the others I added an option to skip these military checks when writing a tender.