### PR TITLE
Expose new fields added for manual data

### DIFF
--- a/api/serializers/bid.js
+++ b/api/serializers/bid.js
@@ -15,11 +15,10 @@ const actorSerializer = require('./actor');
 const lotSerializer = require('./lot');
 
 bidSerializer.formatBid = function (bid) {
-  const formattedBid = _.pick(bid, ['isWinning', 'isSubcontracted']);
-  formattedBid.xYearApproximated = _.get(bid, 'xYearApproximated', false)
+  const formattedBid = _.pick(bid, ['isWinning', 'isSubcontracted', 'xYearApproximated']);
   formattedBid.TEDCANID = bid.xTEDCANID;
   formattedBid.value = _.get(bid, 'price.netAmountEur') || undefined;
-  formattedBid.xAmountApproximated = _.get(bid, 'price.xAmountApproximated', false);
+  formattedBid.xAmountApproximated = _.get(bid, 'price.xAmountApproximated');
   return formattedBid;
 };
 

--- a/api/serializers/bid.js
+++ b/api/serializers/bid.js
@@ -16,8 +16,10 @@ const lotSerializer = require('./lot');
 
 bidSerializer.formatBid = function (bid) {
   const formattedBid = _.pick(bid, ['isWinning', 'isSubcontracted']);
+  formattedBid.xYearApproximated = _.get(bid, 'xYearApproximated', false)
   formattedBid.TEDCANID = bid.xTEDCANID;
   formattedBid.value = _.get(bid, 'price.netAmountEur') || undefined;
+  formattedBid.xAmountApproximated = _.get(bid, 'price.xAmountApproximated', false);
   return formattedBid;
 };
 

--- a/api/serializers/tender.js
+++ b/api/serializers/tender.js
@@ -16,13 +16,12 @@ const actorSerializer = require('./actor');
 
 tenderSerializer.formatTender = function (tender) {
   const formattedTender = _.pick(tender, ['id', 'title', 'titleEnglish', 'description',
-    'isCoveredByGpa', 'isFrameworkAgreement', 'procedureType', 'year', 'country', 'isDirective']);
-  formattedTender.xYearApproximated = _.get(tender, 'xYearApproximated', false)
+    'isCoveredByGpa', 'isFrameworkAgreement', 'procedureType', 'year', 'country', 'isDirective', 'xYearApproximated']);
   formattedTender.isEUFunded = tender.xIsEuFunded;
   formattedTender.TEDCNID = tender.xTEDCNID;
   formattedTender.isDirective = tender.xIsDirective;
   formattedTender.finalValue = _.get(tender, 'finalPrice.netAmountEur') || undefined;
-  formattedTender.xAmountApproximated = _.get(tender, 'finalPrice.xAmountApproximated', false);
+  formattedTender.xAmountApproximated = _.get(tender, 'finalPrice.xAmountApproximated');
   return formattedTender;
 };
 

--- a/api/serializers/tender.js
+++ b/api/serializers/tender.js
@@ -17,10 +17,12 @@ const actorSerializer = require('./actor');
 tenderSerializer.formatTender = function (tender) {
   const formattedTender = _.pick(tender, ['id', 'title', 'titleEnglish', 'description',
     'isCoveredByGpa', 'isFrameworkAgreement', 'procedureType', 'year', 'country', 'isDirective']);
+  formattedTender.xYearApproximated = _.get(tender, 'xYearApproximated', false)
   formattedTender.isEUFunded = tender.xIsEuFunded;
   formattedTender.TEDCNID = tender.xTEDCNID;
   formattedTender.isDirective = tender.xIsDirective;
   formattedTender.finalValue = _.get(tender, 'finalPrice.netAmountEur') || undefined;
+  formattedTender.xAmountApproximated = _.get(tender, 'finalPrice.xAmountApproximated', false);
   return formattedTender;
 };
 

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1562,6 +1562,12 @@ definitions:
       isSubcontracted:
         type: boolean
         description: Did the winner subcontract another company for this bid?
+      xYearApproximated:
+        type: boolean
+        description: Is the bid year approximated (for manually collected data)
+      xAmountApproximated:
+        type: boolean
+        description: Is the bid value approximated
       bidders:
         type: array
         items:
@@ -1647,6 +1653,12 @@ definitions:
       isDirective:
         type: boolean
         description: Is the tender part of Directive 2009/81/EC
+      xYearApproximated:
+        type: boolean
+        description: Is the tender year approximated (for manually collected data)
+      xAmountApproximated:
+        type: boolean
+        description: Is the tender value approximated
   CpvIndexResponse:
     type: object
     properties:


### PR DESCRIPTION
As part of #11, we have added a few fields that are specific to manual data:

`bid.xAmountApproximated: true/false`
`bid.xYearApproximated: true/false`

`tender.xAmountApproximated: true/false`
`tender.xYearApproximated: true/false`

These fields will occur only in manual tenders with a `true`/`false` value. 
Following the general rule of the API, they will not occur in response for TED tenders because the value would always  be `undefined`.

For manual tenders many of the TED fields are not aplicable (`isSubcontracted `, `isWinning`, `TEDCANID`, etc.) and therefore don't appear in the response. 

Here is an example of actor details response (`/networks/{networkID}/nodes/{nodeID}`) from TED contracts:

![image](https://user-images.githubusercontent.com/8862002/75629691-5e3dc900-5be4-11ea-8310-f9c540b69c27.png)

And here is an example of actor details from manual data contracts:

![image](https://user-images.githubusercontent.com/8862002/75629716-8cbba400-5be4-11ea-947b-a44dc0046963.png)

Notice the presence of `xYearApproximated ` and `xAmountAppromitated` and the absence of other fields. 

The general rule is that: if the field is present in the response, it means it has a value in the data that should be displayed in the interface. 
If the field is not present in the response it means it was undefined and it should be displayed in the interface with `-`, left empty or not shown at all depending on the case.





