### PR TITLE
Add sources to tender details

### DIFF
--- a/api/serializers/tender.js
+++ b/api/serializers/tender.js
@@ -15,7 +15,7 @@ const lotSerializer = require('./lot');
 const actorSerializer = require('./actor');
 
 tenderSerializer.formatTender = function (tender) {
-  const formattedTender = _.pick(tender, ['id', 'title', 'titleEnglish', 'description',
+  const formattedTender = _.pick(tender, ['id', 'title', 'titleEnglish', 'description', 'sources',
     'isCoveredByGpa', 'isFrameworkAgreement', 'procedureType', 'year', 'country', 'isDirective', 'xYearApproximated']);
   formattedTender.isEUFunded = tender.xIsEuFunded;
   formattedTender.TEDCNID = tender.xTEDCNID;

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1623,6 +1623,12 @@ definitions:
       year:
         type: integer
         description: Year when the contract notice or contract award notice was published
+      sources:
+        type: array
+        description: Array of tender sources
+        items:
+          type: string
+          description: URL to tender source
       TEDCNID:
         type: string
         description: ID of the Contract Notice on ted.europa.eu

--- a/extractors/manual/lot.js
+++ b/extractors/manual/lot.js
@@ -8,6 +8,7 @@ function extractLot(tenderAttrs) {
   return {
     id: uuidv4(),
     title: tenderAttrs.title,
+    bidsCount: 1,
   };
 }
 


### PR DESCRIPTION
Expose a link to the original tender publication as part of tender details.
The links will be available in a new array field called `tender.sources`.