### PR TITLE
Network update controller logic

### DIFF
--- a/api/controllers/actor_clusters.js
+++ b/api/controllers/actor_clusters.js
@@ -62,8 +62,12 @@ function getCluster(req, res) {
   return Promise.join(
     clusterWriters.retrieveNetwork(networkID),
     clusterWriters.retrieveCluster(networkID, clusterID),
-    (network, networkCluster) =>
-      clusterSerializer.formatClusterWithDetails(network, networkCluster),
+    (network, networkCluster) => {
+      if (network.xUpdateNeeded === true) {
+        throw new codes.BadRequestError('Cluster details unavailable until you update the network.');
+      }
+      return clusterSerializer.formatClusterWithDetails(network, networkCluster)
+    }
   )
     .then((cluster) => res.status(codes.SUCCESS).json({
       cluster,

--- a/api/controllers/network_actors.js
+++ b/api/controllers/network_actors.js
@@ -21,6 +21,9 @@ function getNetworkActor(req, res) {
       if (_.isUndefined(networkActor) === true) {
         throw new codes.NotFoundError('Network actor not found.');
       }
+      if (network.xUpdateNeeded === true) {
+        throw new codes.BadRequestError('Actor details unavailable until you update the network.');
+      }
       return networkActorSerializer.formatActorWithDetails(network, networkActor);
     },
   )

--- a/api/serializers/network.js
+++ b/api/serializers/network.js
@@ -10,7 +10,7 @@ const networkEdgeSerializer = require('./network_edge');
 const actorClusterSerializer = require('./actor_cluster');
 
 function formatNetwork(network) {
-  const prettyNetwork = _.pick(network, ['id', 'name', 'synopsis']);
+  const prettyNetwork = _.pick(network, ['id', 'name', 'synopsis', 'xUpdateNeeded']);
   prettyNetwork.created = moment(network.created).format();
   prettyNetwork.updated = moment(network.updated).format();
   prettyNetwork.settings = _.pick(network.settings, ['nodeSize', 'edgeSize']);

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1237,6 +1237,9 @@ definitions:
         type: string
         format: date-time
         description: When the network was last updated
+      xUpdateNeeded:
+        type: boolean
+        description: Networks are marked for updating after new data has been imported
       count:
         type: object
         properties:

--- a/api/writers/network.js
+++ b/api/writers/network.js
@@ -121,6 +121,7 @@ async function updateNetwork(networkParams, existingNetwork) {
             );
           })
       })
+      .then(() => updatedNetwork)
     );
 }
 

--- a/api/writers/network.js
+++ b/api/writers/network.js
@@ -113,12 +113,21 @@ async function updateNetwork(networkParams, existingNetwork) {
             clusterActorsQuery,
             { params: { networkID: updatedNetwork.id, actorIDs: existingCluster.originalActorIDs}},
           ).then((newClusterActors) => {
-            const newNodeIDs = _.map(newClusterActors, 'id');
-            return clusterWriters.updateCluster(
-              updatedNetwork.id,
-              existingCluster.id,
-              { nodes: newNodeIDs }
-            );
+            if (_.isEmpty(newClusterActors) === true) {
+              // If all the nodes in the cluster have been removed, remove the cluster too
+              return clusterWriters.deleteCluster(
+                updatedNetwork.id,
+                existingCluster.id
+              )
+            } else {
+              // Otherwise update the cluster
+              const newNodeIDs = _.map(newClusterActors, 'id');
+              return clusterWriters.updateCluster(
+                updatedNetwork.id,
+                existingCluster.id,
+                { nodes: newNodeIDs }
+              );
+            }
           })
       })
       .then(() => updatedNetwork)

--- a/api/writers/tender.js
+++ b/api/writers/tender.js
@@ -19,7 +19,7 @@ function recordName(id, className) {
 
 // Returns true
 // Raises OrientDBError if the writing failed
-async function writeTender(fullTenderRecord, skipMilitaryFilters = true) {
+async function writeTender(fullTenderRecord, skipMilitaryFilters = false) {
   const awardedLots = _.filter(fullTenderRecord.lots, { status: 'AWARDED' });
 
   // If there are no awarded lots don't even process the tender

--- a/migrations/m20200523_102828_add_xUpdateNeeded_to_network.js
+++ b/migrations/m20200523_102828_add_xUpdateNeeded_to_network.js
@@ -1,0 +1,20 @@
+"use strict";
+exports.name = "add_updateNeeded_to_network";
+
+
+exports.up = (db) => (
+  db.class.get('Network')
+    .then((Network) =>
+      Network.property.create([
+        {
+          name: 'xUpdateNeeded',
+          type: 'Boolean',
+          default: false,
+        },
+      ]))
+);
+
+exports.down = (db) => (
+  db.class.get('Network')
+    .then((Network) => Network.property.drop('xUpdateNeeded'))
+);

--- a/scripts/mark_networks_for_update.js
+++ b/scripts/mark_networks_for_update.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-console */
+
+'use strict';
+
+const _ = require('lodash');
+const { URL } = require('url');
+const Promise = require('bluebird');
+const moment = require('moment');
+
+const config = require('../config/default');
+const helpers = require('./helpers');
+
+function markNetworksForUpdte() {
+  const currentTime =  moment().format('YYYY-MM-DD HH:mm:ss');
+  const networksToUpdateQuery = `SELECT * FROM Network where updated < '${currentTime}'`;
+  return config.db.query(networksToUpdateQuery)
+    .then((networksToUpdate) => Promise.map(networksToUpdate, (network) =>
+      config.db.update('Network')
+      .set({
+        xUpdateNeeded: true,
+      })
+      .where({ '@rid': network['@rid'] })
+      .return('AFTER')
+      .commit()
+      .one()))
+    .then((updatedNetworks) => {
+      console.log(`Marked ${updatedNetworks.length} networks for update`);
+      process.exit();
+    })
+      .catch((err) => {
+        console.error(err);
+        process.exit(-1);
+      });
+}
+
+markNetworksForUpdte();


### PR DESCRIPTION
This PR implements the changes described in #21.

It:
- adds another field to the network called `xUpdateNeeded` that is `false` by default
- after a new data import the field will be set to `true` for the all the networks created until that point
- networks that are marked for update can be seen (GET /networks/{id}) is allowed but viewing an individual node returns an error message because it wouldn't be possible since the original bids of the NetworkActors have been changed/removed during the update.  Therefore a message is returned saying "Actor details unavailable until you update the network"
- if a request on `PATCH on /netorks/{id}` contains `query` and `settings` the network will be regenerated according to the new `query`/`settings`, from the latest data. By sending the same `query` and `options` one can set off a network refresh