### PR TITLE
Pagination for actor bids

### DIFF
--- a/api/serializers/actor_cluster.js
+++ b/api/serializers/actor_cluster.js
@@ -33,7 +33,17 @@ function formatClusterWithDetails(network, networkCluster) {
         }));
 }
 
+function formatClusterBids(network, networkCluster, limit, page) {
+  return config.db.select("expand(out('Includes'))")
+  .from('NetworkActor')
+  .where({ id: networkCluster.id })
+  .all()
+  .then((nodes) => _.map(nodes, 'id'))
+  .then((nodeIDs) => networkActorSerializer.formatActorBids(network, networkCluster, limit, page, nodeIDs));
+}
+
 module.exports = {
   formatCluster,
   formatClusterWithDetails,
+  formatClusterBids,
 };

--- a/api/serializers/network_actor.js
+++ b/api/serializers/network_actor.js
@@ -53,15 +53,6 @@ function formatActorWithDetails(network, networkActor, nodeIDs) {
       node.percentValuesMissing = 100 - (
         (_.get(details, 'numberOfAvailablePrices', 0) * 100) / details.numberOfWinningBids
       );
-      return Promise.map(details.bidIDs, (bidID) =>
-        config.db.select()
-          .from('Bid')
-          .where({ id: bidID })
-          .one()
-          .then((bid) => bidSerializer.formatBidWithRelated(network, bid)));
-    })
-    .then((bids) => {
-      node.winningBids = bids;
       return node;
     });
 }

--- a/api/serializers/network_actor.js
+++ b/api/serializers/network_actor.js
@@ -66,13 +66,14 @@ function formatActorWithDetails(network, networkActor, nodeIDs) {
     });
 }
 
-function formatActorBids(network, networkActor, limit = 10, page = 1) {
+function formatActorBids(network, networkActor, limit = 10, page = 1, nodeIDs) {
   const edgeToBidClass = networkActor.type === 'buyer' ? 'Awards' : 'Participates';
+  const networkActorIDs = nodeIDs || [networkActor.id];
   const actorIDsQuery = `SELECT expand(in('ActingAs'))
     FROM NetworkActor
-    WHERE id in :networkActorID;`;
+    WHERE id in :networkActorIDs;`;
   const skip = (page - 1) * limit;
-  return config.db.query(actorIDsQuery, { params: { networkActorID: networkActor.id } })
+  return config.db.query(actorIDsQuery, { params: { networkActorIDs: networkActorIDs } })
     .then((actors) => _.map(actors, 'id'))
     .then((actorIDs) => {
       const actorBidsQuery = `SELECT *

--- a/api/serializers/network_edge.js
+++ b/api/serializers/network_edge.js
@@ -55,15 +55,6 @@ function formatContractsEdgeWithDetails(network, networkEdge) {
       edge.percentValuesMissing = 100 - (
         (_.get(details, 'numberOfAvailablePrices', 0) * 100) / details.numberOfWinningBids
       );
-      return Promise.map(details.bidIDs, (bidID) =>
-        config.db.select()
-          .from('Bid')
-          .where({ id: bidID })
-          .one()
-          .then((bid) => bidSerializer.formatBidWithRelated(network, bid)));
-    })
-    .then((bids) => {
-      edge.winningBids = bids;
       return edge;
     });
 }

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -943,6 +943,57 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /networks/{networkID}/nodes/{nodeID}/bids:
+    x-swagger-router-controller: network_actors
+    get:
+      tags:
+        - network node bids
+      description: Get node bids
+      operationId: getNetworkActorBids
+      parameters:
+        - name: networkID
+          type: string
+          in: path
+          description: ID of the network the node is part of
+          required: true
+        - name: nodeID
+          type: string
+          in: path
+          description: ID of the node for which to retrieve the bids
+          required: true
+        - name: limit
+          type: integer
+          in: query
+          description: Limit number of bids returned per page
+          required: false
+          default: 10
+        - name: page
+          type: integer
+          in: query
+          description: Get next set of results
+          required: false
+          default: 1
+      responses:
+        "200":
+          description: Node details returned
+          schema:
+            $ref: "#/definitions/ActorBids"
+        "404":
+          description: Network/node not found
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "400":
+          description: Bad request
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /networks/{networkID}/edges/{edgeID}:
     x-swagger-router-controller: network_edges
     get:
@@ -997,7 +1048,7 @@ paths:
         - name: networkID
           type: string
           in: path
-          description: ID of the network the node is part of
+          description: ID of the network the tender is part of
           required: true
         - name: tenderID
           type: string
@@ -1006,7 +1057,7 @@ paths:
           required: true
       responses:
         "200":
-          description: Node details returned
+          description: Network tender returned
           schema:
             $ref: "#/definitions/NetworkTenderResponse"
         "404":
@@ -1399,7 +1450,7 @@ definitions:
             - type: object
               properties:
                 lot:
-                  description: The the lot for which this bid was applied
+                  description: The lot for which this bid was applied
                   allOf:
                   - $ref: "#/definitions/Lot"
                   - type: object
@@ -1472,6 +1523,22 @@ definitions:
         hidden:
           type: boolean
           description: If the edge is attached to an inactive node it is inactive
+  ActorBids:
+    type: array
+    description: The bids exchanged by an actor
+    items:
+      allOf:
+      - $ref: "#/definitions/Bid"
+      - type: object
+        properties:
+          lot:
+            description: The the lot for which this bid was applied
+            allOf:
+            - $ref: "#/definitions/Lot"
+            - type: object
+              properties:
+                tender:
+                  $ref: "#/definitions/Tender"
   EdgeDetails:
     allOf:
     - $ref: "#/definitions/BaseEdge"

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -915,7 +915,7 @@ paths:
         - name: networkID
           type: string
           in: path
-          description: ID of the network the node is part of
+          description: ID of the network the cluster is part of
           required: true
         - name: clusterID
           type: string
@@ -940,7 +940,7 @@ paths:
           schema:
             $ref: "#/definitions/ActorBids"
         "404":
-          description: Network/node not found
+          description: Network/cluster not found
           schema:
             $ref: "#/definitions/ErrorResponse"
         "400":
@@ -1082,6 +1082,57 @@ paths:
             $ref: "#/definitions/ErrorResponse"
         "501":
           description: Not implemented if an edge of type "partners" is requested
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /networks/{networkID}/edges/{edgeID}/bids:
+    x-swagger-router-controller: network_edges
+    get:
+      tags:
+        - network edge bids
+      description: Get bids exhanged between two actors
+      operationId: getNetworkEdgeBids
+      parameters:
+        - name: networkID
+          type: string
+          in: path
+          description: ID of the network the edge is part of
+          required: true
+        - name: edgeID
+          type: string
+          in: path
+          description: ID of the edge for which to retrieve the bids
+          required: true
+        - name: limit
+          type: integer
+          in: query
+          description: Limit number of bids returned per page
+          required: false
+          default: 10
+        - name: page
+          type: integer
+          in: query
+          description: Get next set of results
+          required: false
+          default: 1
+      responses:
+        "200":
+          description: Edge bids returned
+          schema:
+            $ref: "#/definitions/ActorBids"
+        "404":
+          description: Network/edge not found
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "400":
+          description: Bad request
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "500":
+          description: Internal Server Error
           schema:
             $ref: "#/definitions/ErrorResponse"
         default:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -904,6 +904,57 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /networks/{networkID}/cluster/{clusterID}/bids:
+    x-swagger-router-controller: actor_clusters
+    get:
+      tags:
+        - network cluster bids
+      description: Get cluster bids
+      operationId: getClusterBids
+      parameters:
+        - name: networkID
+          type: string
+          in: path
+          description: ID of the network the node is part of
+          required: true
+        - name: clusterID
+          type: string
+          in: path
+          description: ID of the cluster for which to retrieve the bids
+          required: true
+        - name: limit
+          type: integer
+          in: query
+          description: Limit number of bids returned per page
+          required: false
+          default: 10
+        - name: page
+          type: integer
+          in: query
+          description: Get next set of results
+          required: false
+          default: 1
+      responses:
+        "200":
+          description: Cluster bids returned
+          schema:
+            $ref: "#/definitions/ActorBids"
+        "404":
+          description: Network/node not found
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "400":
+          description: Bad request
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /networks/{networkID}/nodes/{nodeID}:
     x-swagger-router-controller: network_actors
     get:
@@ -975,7 +1026,7 @@ paths:
           default: 1
       responses:
         "200":
-          description: Node details returned
+          description: Node bids returned
           schema:
             $ref: "#/definitions/ActorBids"
         "404":

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1543,22 +1543,6 @@ definitions:
           type: number
           format: double
           description: What percent of this actor's bids have the value undisclosed
-        winningBids:
-          type: array
-          description: The winning bids of this actor
-          items:
-            allOf:
-            - $ref: "#/definitions/Bid"
-            - type: object
-              properties:
-                lot:
-                  description: The lot for which this bid was applied
-                  allOf:
-                  - $ref: "#/definitions/Lot"
-                  - type: object
-                    properties:
-                      tender:
-                        $ref: "#/definitions/Tender"
   NetworkCluster:
     allOf:
     - $ref: "#/definitions/NetworkNode"
@@ -1657,22 +1641,6 @@ definitions:
           type: number
           format: double
           description: What percent of the bids between these two actors have the value undisclosed
-        winningBids:
-          type: array
-          description: The bids awarded by this buyer to this bidder
-          items:
-            allOf:
-            - $ref: "#/definitions/Bid"
-            - type: object
-              properties:
-                lot:
-                  description: The the lot for which this bid was applied
-                  allOf:
-                  - $ref: "#/definitions/Lot"
-                  - type: object
-                    properties:
-                      tender:
-                        $ref: "#/definitions/Tender"
   NetworkTender:
     allOf:
     - $ref: "#/definitions/Tender"


### PR DESCRIPTION
Fixes #24  

The list of `winningBids` was removed from the node, edge and cluster details payload (`/networks/{networkID}/nodes/{nodeID}`, `/networks/{networkID}/edges/{edgeID}/` ) because it was slowing things down significantly for nodes with many tenders.

Instead I created 3 new endpoints where the bids can be retrieved in a paginated way to avoid long and heavy requests:

- `/networks/{networkID}/nodes/{nodeID}/bids` - to retrieve the tenders of an actor
- `/networks/{networkID}/clusters/{clusterID}/bids` - to retrieve the tenders of a cluster
- `/networks/{networkID}/edges/{edgeID}/bids` - to retrieve the tenders of an edge

All the 3 endpoints support 2 parameters for pagination:
- `limit` - how many tenders should be returned per page
- `page` - number of the page, should be increased as you load results until the response is empty

To load the first 10 results of a node, for example you can make the following request:

`GET /networks/{networkID}/nodes/{nodeID}/bids?limit=10&page=1`

Then to load the next 10 results you would do 

`GET /networks/{networkID}/nodes/{nodeID}/bids?limit=10&page=2` 

and so on until you retrieve all the results.

You can tell that you've reached the last page by the fact that the number of results is < limit. 
If you keep going to further pages you will just get an empty array.

 