### PR TITLE
Add pagination details

### DIFF
--- a/api/controllers/actor_clusters.js
+++ b/api/controllers/actor_clusters.js
@@ -88,6 +88,15 @@ function getClusterBids(req, res) {
         throw new codes.BadRequestError('Cluster bids unavailable until you update the network.');
       }
       return clusterSerializer.formatClusterBids(network, networkCluster, limit, page)
+      .then((formattedClusterBids) => {
+        const formattedResponse = {
+          page: page,
+          resultsPerPage: limit,
+          totalResults: networkCluster.numberOfWinningBids,
+          bids: formattedClusterBids,
+        }
+        return formattedResponse;
+      });
     }
   )
     .then((networkClusterBids) => res.status(codes.SUCCESS).json(networkClusterBids))

--- a/api/controllers/actor_clusters.js
+++ b/api/controllers/actor_clusters.js
@@ -93,6 +93,7 @@ function getClusterBids(req, res) {
           page: page,
           resultsPerPage: limit,
           totalResults: networkCluster.numberOfWinningBids,
+          totalPages: Math.ceil(networkCluster.numberOfWinningBids/limit),
           bids: formattedClusterBids,
         }
         return formattedResponse;

--- a/api/controllers/network_actors.js
+++ b/api/controllers/network_actors.js
@@ -57,6 +57,7 @@ function getNetworkActorBids(req, res) {
           page: page,
           resultsPerPage: limit,
           totalResults: networkActor.numberOfWinningBids,
+          totalPages: Math.ceil(networkActor.numberOfWinningBids/limit),
           bids: formattedActorBids,
         }
         return formattedResponse;

--- a/api/controllers/network_actors.js
+++ b/api/controllers/network_actors.js
@@ -51,7 +51,16 @@ function getNetworkActorBids(req, res) {
       if (network.xUpdateNeeded === true) {
         throw new codes.BadRequestError('Actor bids unavailable until you update the network.');
       }
-      return networkActorSerializer.formatActorBids(network, networkActor, limit, page);
+      return networkActorSerializer.formatActorBids(network, networkActor, limit, page)
+      .then((formattedActorBids) => {
+        const formattedResponse = {
+          page: page,
+          resultsPerPage: limit,
+          totalResults: networkActor.numberOfWinningBids,
+          bids: formattedActorBids,
+        }
+        return formattedResponse;
+      });
     },
   )
     .then((networkActorBids) => res.status(codes.SUCCESS).json(networkActorBids))

--- a/api/controllers/network_edges.js
+++ b/api/controllers/network_edges.js
@@ -64,6 +64,7 @@ function getNetworkEdgeBids(req, res) {
           page: page,
           resultsPerPage: limit,
           totalResults: networkEdge.numberOfWinningBids,
+          totalPages: Math.ceil(networkEdge.numberOfWinningBids/limit),
           bids: formattedEdgeBids,
         }
         return formattedResponse;

--- a/api/controllers/network_edges.js
+++ b/api/controllers/network_edges.js
@@ -58,7 +58,16 @@ function getNetworkEdgeBids(req, res) {
       if (networkEdge.type === 'partners') {
         throw new codes.NotImplementedError('No details available for an edge of type "partners".');
       }
-      return edgeSerializer.formatContractsEdgeBids(network, networkEdge, limit, page);
+      return edgeSerializer.formatContractsEdgeBids(network, networkEdge, limit, page)
+      .then((formattedEdgeBids) => {
+        const formattedResponse = {
+          page: page,
+          resultsPerPage: limit,
+          totalResults: networkEdge.numberOfWinningBids,
+          bids: formattedEdgeBids,
+        }
+        return formattedResponse;
+      });
     },
   )
     .then((networkEdgeBids) => res.status(codes.SUCCESS).json(networkEdgeBids))

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1625,6 +1625,10 @@ definitions:
         type: number
         format: double
         description: Total number of results
+      totalPages:
+        type: number
+        format: double
+        description: Total number of pages with results
       bids:
         type: array
         description: The bids exchanged by an actor

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1610,21 +1610,37 @@ definitions:
           type: boolean
           description: If the edge is attached to an inactive node it is inactive
   ActorBids:
-    type: array
-    description: The bids exchanged by an actor
-    items:
-      allOf:
-      - $ref: "#/definitions/Bid"
-      - type: object
-        properties:
-          lot:
-            description: The the lot for which this bid was applied
-            allOf:
-            - $ref: "#/definitions/Lot"
-            - type: object
-              properties:
-                tender:
-                  $ref: "#/definitions/Tender"
+    type: object
+    description: The bids that belong to this actor, paginated
+    properties:
+      page:
+        type: number
+        format: double
+        description: Number of the currently returned page
+      resultsPerPage:
+        type: number
+        format: double
+        description: Number of results returned per page
+      totalResults:
+        type: number
+        format: double
+        description: Total number of results
+      bids:
+        type: array
+        description: The bids exchanged by an actor
+        items:
+          allOf:
+          - $ref: "#/definitions/Bid"
+          - type: object
+            properties:
+              lot:
+                description: The the lot for which this bid was applied
+                allOf:
+                - $ref: "#/definitions/Lot"
+                - type: object
+                  properties:
+                    tender:
+                      $ref: "#/definitions/Tender"
   EdgeDetails:
     allOf:
     - $ref: "#/definitions/BaseEdge"

--- a/api/writers/actor_cluster.js
+++ b/api/writers/actor_cluster.js
@@ -22,6 +22,8 @@ async function createCluster(networkID, clusterParams) {
     countries: _.compact(_.uniq(calcuatedAttrs.countries)),
     value: calcuatedAttrs[network.settings.nodeSize],
     medianCompetition: calcuatedAttrs.medianCompetition,
+    amountOfMoneyExchanged: calcuatedAttrs.amountOfMoneyExchanged,
+    numberOfWinningBids: calcuatedAttrs.amountOfMoneyExchanged,
   };
   const clusterName = networkWriters.recordName(clusterAttrs.id, 'ActorCluster');
   const transaction = config.db.let(clusterName, (t) => {
@@ -66,6 +68,8 @@ async function updateCluster(networkID, clusterID, clusterParams) {
     Object.assign(clusterAttrs, {
       value: calcuatedAttrs[network.settings.nodeSize],
       medianCompetition: calcuatedAttrs.medianCompetition,
+      amountOfMoneyExchanged: calcuatedAttrs.amountOfMoneyExchanged,
+      numberOfWinningBids: calcuatedAttrs.amountOfMoneyExchanged,
     });
   }
 

--- a/api/writers/actor_cluster.js
+++ b/api/writers/actor_cluster.js
@@ -23,7 +23,7 @@ async function createCluster(networkID, clusterParams) {
     value: calcuatedAttrs[network.settings.nodeSize],
     medianCompetition: calcuatedAttrs.medianCompetition,
     amountOfMoneyExchanged: calcuatedAttrs.amountOfMoneyExchanged,
-    numberOfWinningBids: calcuatedAttrs.amountOfMoneyExchanged,
+    numberOfWinningBids: calcuatedAttrs.numberOfWinningBids,
   };
   const clusterName = networkWriters.recordName(clusterAttrs.id, 'ActorCluster');
   const transaction = config.db.let(clusterName, (t) => {
@@ -69,7 +69,7 @@ async function updateCluster(networkID, clusterID, clusterParams) {
       value: calcuatedAttrs[network.settings.nodeSize],
       medianCompetition: calcuatedAttrs.medianCompetition,
       amountOfMoneyExchanged: calcuatedAttrs.amountOfMoneyExchanged,
-      numberOfWinningBids: calcuatedAttrs.amountOfMoneyExchanged,
+      numberOfWinningBids: calcuatedAttrs.numberOfWinningBids,
     });
   }
 

--- a/api/writers/network.js
+++ b/api/writers/network.js
@@ -194,7 +194,7 @@ function createBidderNodes(transaction, networkSettings, networkQuery, networkNa
     .then((bidderNodes) => Promise.map(bidderNodes, (node) => {
       const nodeAttrs = _.pick(
         node,
-        ['label', 'medianCompetition'],
+        ['label', 'medianCompetition', 'amountOfMoneyExchanged', 'numberOfWinningBids'],
       );
       nodeAttrs.id = uuidv4();
       nodeAttrs.type = 'bidder';
@@ -229,7 +229,7 @@ function createBuyerNodes(transaction, networkSettings, networkQuery, networkNam
     .then((buyerNodes) => Promise.map(buyerNodes, (node) => {
       const nodeAttrs = _.pick(
         node,
-        ['label', 'medianCompetition'],
+        ['label', 'medianCompetition', 'amountOfMoneyExchanged', 'numberOfWinningBids'],
       );
       nodeAttrs.id = uuidv4();
       nodeAttrs.type = 'buyer';
@@ -292,6 +292,8 @@ function createContractsEdges(transaction, networkSettings, networkQuery, networ
       const edgeAttrs = {
         uuid: uuidv4(),
         value: edge[networkSettings.edgeSize],
+        numberOfWinningBids: edge.numberOfWinningBids,
+        amountOfMoneyExchanged: edge.amountOfMoneyExchanged,
         active: true,
       };
       const fromName = networkActorsMapping[edge.buyerRID];

--- a/migrations/m20200803_192027_add_numberOfWinningBids_amountOfMoneyExchanged_to_networkActor.js
+++ b/migrations/m20200803_192027_add_numberOfWinningBids_amountOfMoneyExchanged_to_networkActor.js
@@ -1,0 +1,27 @@
+'use strict';
+exports.name = 'add_numberOfWinningBids_amountOfMoneyExchanged_to_networkActor';
+
+const Promise = require('bluebird');
+
+exports.up = (db) => (
+  db.class.get('NetworkActor')
+    .then((NetworkActor) =>
+      NetworkActor.property.create([
+        {
+          name: 'numberOfWinningBids',
+          type: 'Integer',
+        },
+        {
+          name: 'amountOfMoneyExchanged',
+          type: 'Integer',
+        },
+      ]))
+);
+
+exports.down = (db) => (
+  Promise.map(['numberOfWinningBids', 'amountOfMoneyExchanged'], (propName) => {
+    db.class.get('NetworkActor')
+      .then((NetworkActor) => NetworkActor.property.drop(propName));
+  })
+);
+

--- a/migrations/m20200803_194814_remove_flags_from_networkActor.js
+++ b/migrations/m20200803_194814_remove_flags_from_networkActor.js
@@ -1,0 +1,19 @@
+"use strict";
+exports.name = "remove_flags_from_networkActor";
+
+exports.up = function (db) {
+  db.class.get('NetworkActor')
+    .then((NetworkActor) => NetworkActor.property.drop('flags'))
+};
+
+exports.down = function (db) {
+  db.class.get('NetworkActor')
+  .then((NetworkActor) =>
+    NetworkActor.property.create([
+      {
+        name: 'flags',
+        type: 'EmbeddedList',
+      },
+    ]))
+};
+

--- a/migrations/m20200806_190709_add_numberOfWinningBids_amountOfMoneyExchanged_to_networkEdge.js
+++ b/migrations/m20200806_190709_add_numberOfWinningBids_amountOfMoneyExchanged_to_networkEdge.js
@@ -1,0 +1,26 @@
+"use strict";
+exports.name = "add_numberOfWinningBids_amountOfMoneyExchanged_to_networkEdge";
+
+const Promise = require('bluebird');
+
+exports.up = (db) => (
+  db.class.get('NetworkEdge')
+    .then((NetworkEdge) =>
+      NetworkEdge.property.create([
+        {
+          name: 'numberOfWinningBids',
+          type: 'Integer',
+        },
+        {
+          name: 'amountOfMoneyExchanged',
+          type: 'Integer',
+        },
+      ]))
+);
+
+exports.down = (db) => (
+  Promise.map(['numberOfWinningBids', 'amountOfMoneyExchanged'], (propName) => {
+    db.class.get('NetworkEdge')
+      .then((NetworkEdge) => NetworkEdge.property.drop(propName));
+  })
+);


### PR DESCRIPTION
Add total number of results to help with pagination. Also refactored node details to same `numberOfWinningBids` and `amountOfMoneyExhanged` on node calculation so that we don't have to keep recalculating them further on. 

The paginated results on `/node/{nodeID}/bids`,  `edge/{edgeId}/bids`  `/cluster/{clusterID}/bids`  now look like this:

```
{
  "page": "{number of the current page}",
  "resultsPerPage": "{current number of results to be returned per page}",
  "totalResults": "{total number of results}",
  "totalPages": "{number of pages with results}",
  "bids": [{array of bids exactly as they looked like before}]
}
```
