### PR TITLE
Fix issues in cluster details

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -904,7 +904,7 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
-  /networks/{networkID}/cluster/{clusterID}/bids:
+  /networks/{networkID}/clusters/{clusterID}/bids:
     x-swagger-router-controller: actor_clusters
     get:
       tags:

--- a/api/writers/actor_cluster.js
+++ b/api/writers/actor_cluster.js
@@ -355,12 +355,12 @@ function createContractsEdges(transaction, edgeToBidClass, network, actorIDs, cl
   });
 }
 
-function createContractsEdge(transaction, network, attrs, contractorNode, clusterName) {
+function createContractsEdge(transaction, network, edgeValues, contractorNode, clusterName) {
   const edgeAttrs = {
     uuid: uuidv4(),
-    value: attrs.value,
-    numberOfWinningBids: attrs.numberOfWinningBids,
-    amountOfMoneyExchanged: attrs.amountOfMoneyExchanged,
+    value: edgeValues.value,
+    numberOfWinningBids: edgeValues.numberOfWinningBids,
+    amountOfMoneyExchanged: edgeValues.amountOfMoneyExchanged,
     active: true,
   };
   const partnerName = networkWriters.recordName(contractorNode.id, contractorNode['@class']);

--- a/api/writers/actor_cluster.js
+++ b/api/writers/actor_cluster.js
@@ -297,8 +297,12 @@ function createContractsEdges(transaction, edgeToBidClass, network, actorIDs, cl
     return Promise.map(contractsEdges, (edge) =>
       retrieveNetworkActor(edge.contractorID, network.id)
         .then((contractorNode) => {
-          const edgeValue = edge[network.settings.edgeSize];
-          return createContractsEdge(transaction, network, edgeValue, contractorNode, clusterName);
+          const edgeAttrs = {
+            value: edge[network.settings.edgeSize],
+            numberOfWinningBids: edge.numberOfWinningBids,
+            amountOfMoneyExchanged: edge.amountOfMoneyExchanged,
+          }
+          return createContractsEdge(transaction, network, edgeAttrs, contractorNode, clusterName);
         }))
       .then(() => {
         // Calculate Contracts edges with other clusters in the network
@@ -339,18 +343,24 @@ function createContractsEdges(transaction, edgeToBidClass, network, actorIDs, cl
               { params: queryParams },
             ),
             (contractorCluster, edgeResult) => {
-              const edgeValue = edgeResult[0][network.settings.edgeSize];
-              return createContractsEdge(transaction, network, edgeValue, contractorCluster, clusterName); // eslint-disable-line max-len
+              const edgeAttrs = {
+                value: edgeResult[0][network.settings.edgeSize],
+                numberOfWinningBids: edgeResult[0].numberOfWinningBids,
+                amountOfMoneyExchanged: edgeResult[0].amountOfMoneyExchanged,
+              }
+              return createContractsEdge(transaction, network, edgeAttrs, contractorCluster, clusterName); // eslint-disable-line max-len
             },
           );
         }));
   });
 }
 
-function createContractsEdge(transaction, network, edgeValue, contractorNode, clusterName) {
+function createContractsEdge(transaction, network, attrs, contractorNode, clusterName) {
   const edgeAttrs = {
     uuid: uuidv4(),
-    value: edgeValue,
+    value: attrs.value,
+    numberOfWinningBids: attrs.numberOfWinningBids,
+    amountOfMoneyExchanged: attrs.amountOfMoneyExchanged,
     active: true,
   };
   const partnerName = networkWriters.recordName(contractorNode.id, contractorNode['@class']);


### PR DESCRIPTION
There were 3 issues with cluster details:
- the cluster `procentOfValuesMissing` was always null
- the bids were missing from the edges of the cluster
- the `numberOfWinningBids` and `amountOfMoneyExchanged` was missing from the cluster edges

This PR fixes all of these issues. 