### PR TITLE
Bids ordered by price

### DIFF
--- a/api/serializers/network_actor.js
+++ b/api/serializers/network_actor.js
@@ -63,6 +63,7 @@ function formatActorBids(network, networkActor, limit = 10, page = 1, nodeIDs) {
         WHERE ${_.join(networkWriters.queryToBidFilters(network.query), ' AND ')}
         AND in('${edgeToBidClass}').id in :actorIDs
         AND isWinning=true
+        ORDER BY price.netAmountEur DESC
         LIMIT :limit
         SKIP :skip;`;
       const params = Object.assign({}, network.query, {

--- a/api/serializers/network_edge.js
+++ b/api/serializers/network_edge.js
@@ -74,6 +74,7 @@ function formatContractsEdgeBids(network, networkEdge, limit, page) {
         WHERE ${_.join(networkWriters.queryToBidFilters(network.query), ' AND ')}
         AND in('Awards').id in :edgeBuyerIDs
         AND in('Participates').id in :edgeBidderIDs
+        ORDER BY price.netAmountEur DESC
         AND isWinning=true
         LIMIT :limit
         SKIP :skip;`;


### PR DESCRIPTION
As part of a review call, we have decided it would be much more useful to show the bigger bids first in the list, so we now going to return exactly as before, paginated, but with the highest price on the first page. 