### PR TITLE
Include only data that also appears in OpenTender

### DIFF
--- a/api/writers/tender.js
+++ b/api/writers/tender.js
@@ -22,6 +22,11 @@ function recordName(id, className) {
 async function writeTender(fullTenderRecord, skipMilitaryFilters = false) {
   const awardedLots = _.filter(fullTenderRecord.lots, { status: 'AWARDED' });
 
+  // If the tender is not in opentender, skip it
+  if (_.get(fullTenderRecord, 'metaData.opentender', true) === false ) {
+    return new Promise((resolve) => resolve(null));
+  }
+
   // If there are no awarded lots don't even process the tender
   if (awardedLots.length === 0) {
     return new Promise((resolve) => resolve(null));


### PR DESCRIPTION
For opentender data, some of the records we have in the data are not being displayed on the https://opentender.eu/ website because they might be possible duplicates of existing tenders that come from different data portals. Since we also want to avoid displaying duplicates and we're trying to link every tender to its original source on the opentender website, we decided to remove those as well. 

This feature adds the functionality to skip the tenders that are not displayed by the https://opentender.eu/  website. 